### PR TITLE
Add video services to whitelist

### DIFF
--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -71,3 +71,4 @@ api.zerossl.com
 # Video streaming services
 youtube.com
 vimeo.com
+#

--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -68,4 +68,6 @@ api.buypass.com
 api.test4.buypass.no
 acme.zerossl.com
 api.zerossl.com
-#
+# Video streaming services
+youtube.com
+vimeo.com


### PR DESCRIPTION
Hello,

First of all, I want to thank you for this amazing service, which I recently discovered... It is a great pleasure to work with it ! I recently encountered a few problems with a project of mine, which makes some very light use of Youtube (occasional metadata downloading). Since this website is :  

> 1. Completely free service
> 2. Used by a lot of people
> 3. Easily handle million hits

...I hereby suggest to add it to the Firewall whitelist. Please forgive me if this request seems dumb to you... I'm no professional, and I probably don't understand every implication of such a modification ! Especially I don't know if this modification would be compatible with the ToS preventing any Streaming usage of your servers.