### PR TITLE
Update sites.conf

### DIFF
--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -163,6 +163,7 @@ smtp.mailgun.org
 send.api.mailtrap.io
 sandbox.smtp.mailtrap.io
 live.smtp.mailtrap.io
+smtp.zoho.in
 # PaaS / Database
 api.aiven.io
 api.cloudflare.com


### PR DESCRIPTION
Added Zoho Mail SMTP service to the whitelist URL for use.

Documentation link for Zoho
https://www.zoho.com/mail/help/zoho-smtp.html#tls