### PR TITLE
Add fonnte API endpoint

### DIFF
--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -266,4 +266,5 @@ wdc.domcloud.co
 nue.domcloud.co
 osk.domcloud.co
 sao.domcloud.co
-#
+# Fonnte
+api.fonnte.com


### PR DESCRIPTION
#### Summary
This PR  adds Fonnte's public API domain (`api.fonnte.com`) to `src/whitelist/sites.conf`
#### About Fonnte
[Fonnte](https://fonnte.com) is a third-party service that provides a simple WhatsApp API for sending messages to users. It offers both paid and free tiers. The free tier, while limited in features and message quotas, allows sending messages using an API key without requiring device pairing.
#### Reason for the Change
Adding `api.fonnte.com` to `sites.conf` ensures that applications hosted on DOM Cloud using Passenger or restricted environments are able to make outbound HTTPS requests to the Fonnte API without being blocked by network rules.

This is particularly helpful for developers implementing notification systems (e.g., for user login, OTP delivery, or system alerts) using the Fonnte platform.

#### API Public Documentation
[https://docs.fonnte.com/category/api/](https://docs.fonnte.com/category/api/)

##### Thanks for making DOM Cloud, I learned a lot because of you.