### PR TITLE
add cdn.skypack.dev to CDN whitelist

### DIFF
--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -180,6 +180,7 @@ cdnjs.cloudflare.com
 one.one.one.one
 dns.google
 unpkg.com
+cdn.skypack.dev
 # Tools
 api.abuseipdb.com
 api.duckduckgo.com


### PR DESCRIPTION
Skypack is a public ESM CDN with open documentation. Some projects require fetching modules during build or runtime, but current firewall rules block access. Adding cdn.skypack.dev aligns with other allowed CDNs (jsdelivr, unpkg, etc.).

Docs: https://docs.skypack.dev/

@willnode 
Change-Id: Id53b18c960c9b6c795f75b90e2d740d65e479bd6
