### PR TITLE
Add OpenWeatherMap and OpenRouter APIs to outbound whitelist

### DIFF
--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -260,6 +260,7 @@ api.x.ai
 api-inference.huggingface.co
 generativelanguage.googleapis.com
 ollama.com
+openrouter.ai
 # Social Media APIs
 api.giphy.com
 api.imgur.com
@@ -274,6 +275,7 @@ graph.threads.net
 www.reddit.com
 api.fonnte.com
 bsky.social
+api.openweathermap.org
 # Intranets
 sga.domcloud.co
 sgp.domcloud.co


### PR DESCRIPTION
These are free, publicly documented APIs.

- api.openweathermap.org (docs: https://openweathermap.org/api)
- openrouter.ai (docs: https://openrouter.ai/docs/quickstart)