### PR TITLE
Add api.deepinfra.com to whitelist

### DIFF
--- a/src/whitelist/sites.conf
+++ b/src/whitelist/sites.conf
@@ -263,6 +263,7 @@ api-inference.huggingface.co
 generativelanguage.googleapis.com
 ollama.com
 openrouter.ai
+api.deepinfra.com
 # Social Media APIs
 api.giphy.com
 api.imgur.com


### PR DESCRIPTION
This PR proposes adding api.deepinfra.com to the outbound whitelist.

Rationale:
- DeepInfra provides public documentation for its API.
- DeepInfra also offers testing access that can be used without an API key, with limits.
- DOM Cloud’s whitelist policy allows public endpoints that are not behind a paywall; free access with an API token is acceptable.

Docs:
- https://docs.deepinfra.com/chat/overview
- https://docs.deepinfra.com/apis/deepinfra-native